### PR TITLE
deprecate doc-biblioentry and doc-endnote

### DIFF
--- a/index.html
+++ b/index.html
@@ -692,29 +692,15 @@
 				<div class="role">
 					<rdef>doc-biblioentry</rdef>
 					<div class="role-description">
-						<p>A single reference to an external source in a bibliography. A biblioentry typically provides more
-							detailed information than its reference(s) in the content (e.g., full title, author(s), publisher,
-							publication date, etc.).</p>
-						<p>Authors MUST ensure that <a>elements</a> with role <code>doc-biblioentry</code> are contained in,
-							or owned, by an element with the role <rref>list</rref>.</p>
-						<pre class="example highlight">&lt;section role="doc-bibliography"&gt;
-   &lt;h1&gt;Cited Works&lt;/h1&gt;
-   &lt;div role="list"&gt;
-      &lt;p role="doc-biblioentry" id="b8cab5dd-bc24-459c-9858-7afa9da69b64"&gt;
-         John Steinbeck, The Grapes of Wrath (New York: The Viking Press, 1939)
-      &lt;/p&gt;
-   &lt;/div&gt;
-   &#8230;
-&lt;/section&gt;</pre>
-						<pre class="example highlight">&lt;section role="doc-bibliography"&gt;
-   &lt;h1&gt;Select Bibliography&lt;/h1&gt;
-   &lt;ul&gt;
-      &lt;li role="doc-biblioentry" id="faulkner-dying"&gt;
-         William Faulkner, As I Lay Dying (New York: Jonathan Cape &amp; Harrison Smith, 1930)
-      &lt;/li&gt;
-   &lt;/ul&gt;
-   &#8230;
-&lt;/section&gt;</pre>
+						<p>[Deprecated in DPUB-ARIA 1.1] A single reference to an external source in a bibliography. A
+							biblioentry typically provides more detailed information than its reference(s) in the content
+							(e.g., full title, author(s), publisher, publication date, etc.).</p>
+						<p class="note">The <code>doc-biblioentry</code>
+							<a>role</a> was designed for use as a list item, but due to clarifications in the WAI-ARIA
+							specification, it is not valid as a child of the <rref>list</rref> role. As the
+								<rref>doc-bibliography</rref> role already identifies a section of bibliography entries, authors
+							are instead advised to use the <rref>list</rref> and <rref>listitem</rref> roles when native HTML
+							elements cannot be used to structure the entries.</p>
 					</div>
 					<table class="role-features">
 						<caption>Characteristics:</caption>
@@ -731,7 +717,7 @@
 							</tr>
 							<tr>
 								<th class="role-parent-head" scope="row">Superclass Role:</th>
-								<td class="role-parent"><rref>listitem</rref></td>
+								<td class="role-parent"> </td>
 							</tr>
 							<tr>
 								<th class="role-children-head" scope="row">Subclass Roles:</th>
@@ -749,7 +735,7 @@
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
-								<td class="role-scope"><rref>doc-bibliography</rref></td>
+								<td class="role-scope"> </td>
 							</tr>
 							<tr>
 								<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
@@ -842,7 +828,7 @@
 							</tr>
 							<tr>
 								<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-								<td class="role-mustcontain"><rref>doc-biblioentry</rref></td>
+								<td class="role-mustcontain"> </td>
 							</tr>
 							<tr>
 								<th class="role-required-properties-head">Required States and Properties:</th>
@@ -1576,33 +1562,15 @@
 				<div class="role">
 					<rdef>doc-endnote</rdef>
 					<div class="role-description">
-						<p>One of a collection of notes that occur at the end of a work, or a section within it, that provides
-							additional context to a referenced passage of text.</p>
-						<p>Authors MUST ensure that <a>elements</a> with <a>role</a>
-							<code>doc-endnote</code> are contained in, or owned, by an element with the role
-							<rref>list</rref>.</p>
-						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
-   &lt;h2&gt;Notes&lt;/h2&gt;
-   &lt;ol&gt;
-      &lt;li id="6baa07af" role="doc-endnote"&gt;Additional results of this study can be found at &#8230; &lt;/li&gt;
-      &lt;li id="7b2c0555" role="doc-endnote"&gt;&#8230;&lt;/li&gt;
-      &#8230;
-   &lt;/ol&gt;
-&lt;/section&gt;</pre>
-						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
-   &lt;h2&gt;Notes&lt;/h2&gt;
-   &lt;section id="ch1-notes"&gt;
-      &lt;h3&gt;Chapter 1&lt;/h3&gt;
-      &lt;div role="list"&gt;
-         &lt;p id="6baa07af" role="doc-endnote"&gt;1. Additional results of this study can be found at &#8230; &lt;/p&gt;
-         &lt;div id="7b2c0555" role="doc-endnote"&gt;
-            &lt;p&gt;2. The primary source of information &#8230;&lt;/p&gt;
-            &lt;p class="note-cont"&gt;In the case of secondary studies &#8230;&lt;/p&gt;
-         &lt;/div&gt;
-         &#8230;
-      &lt;/div&gt;
-   &lt;/section&gt;
-&lt;/section&gt;</pre>
+						<p>[Deprecated in DPUB-ARIA 1.1] One of a collection of notes that occur at the end of a work, or a
+							section within it, that provides additional context to a referenced passage of text.</p>
+						<p class="note">The <code>doc-endnote</code>
+							<a>role</a> was designed for use as a list item, but due to clarifications in the WAI-ARIA
+							specification, it is not valid as a child of the <rref>list</rref> role. As the
+								<rref>doc-endnotes</rref> role already identifies a section of endnotes, authors are instead
+							advised to use the <rref>list</rref> and <rref>listitem</rref> roles when native HTML elements
+							cannot be used to structure the entries. The <rref>doc-footnote</rref> role can be used within each
+							list item to identify individual notes when necessary.</p>
 					</div>
 					<table class="role-features">
 						<caption>Characteristics:</caption>
@@ -1636,7 +1604,7 @@
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
-								<td class="role-scope"><rref>doc-endnotes</rref></td>
+								<td class="role-scope"> </td>
 							</tr>
 							<tr>
 								<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
@@ -1686,13 +1654,16 @@
 					<div class="role-description">
 						<p>A collection of notes at the end of a work or a section within it.</p>
 						<p>Note that the <code>doc-endnotes</code>
-							<a>role</a> is never applied directly to the list of endnotes. See the <rref>doc-endnote</rref>
-							role for more information.</p>
+							<a>role</a> is never applied directly to the list of endnotes.</p>
 						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
    &lt;h2&gt;Notes&lt;/h2&gt;
    &lt;ol&gt;
-      &lt;li id="6baa07af" role="doc-endnote"&gt;Additional results of this study can be found at &#8230; &lt;/li&gt;
-      &lt;li id="7b2c0555" role="doc-endnote"&gt;&#8230;&lt;/li&gt;
+      &lt;li id="6baa07af"&gt;
+         &lt;p role="doc-footnote"&gt;Additional results of this study can be found at &#8230; &lt;/p&gt;
+      &lt;/li&gt;
+      &lt;li id="7b2c0555"&gt;
+         &lt;p role="doc-footnote"&gt;&#8230;&lt;/p&gt;
+      &lt;/li&gt;
       &#8230;
    &lt;/ol&gt;
 &lt;/section&gt;</pre>
@@ -1733,7 +1704,7 @@
 							</tr>
 							<tr>
 								<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-								<td class="role-mustcontain"><rref>doc-endnote</rref></td>
+								<td class="role-mustcontain"> </td>
 							</tr>
 							<tr>
 								<th class="role-required-properties-head">Required States and Properties:</th>
@@ -3880,41 +3851,20 @@
 		<section class="appendix informative" id="changelog">
 			<h2>Change Log</h2>
 			<section>
-				<h2>Substantive changes since the <a href="https://www.w3.org/TR/2016/WD-dpub-aria-1.0-20160317/">last
-						public working draft</a></h2>
+				<h2>Substantive changes since the <a href="https://www.w3.org/TR/dpub-aria-1.0/">DPUB-ARIA 1.0
+						Recommendation</a></h2>
 				<ul>
 					<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
-					<li>29-Sept-2016: Updated <rref>doc-index</rref> to inherit from <rref>navigation</rref> role and changed
-						"Name from" calculation to "author".</li>
+					<li>23-July-2020: Deprecated the <rref>doc-biblioentry</rref> and <rref>doc-endnote</rref> roles due to
+						the inability of them to be recognized as children of <rref>list</rref>.</li>
 				</ul>
 			</section>
-			<section>
+			<!-- <section>
 				<h2>Other substantive changes since the <a href="http://www.w3.org/TR/2015/WD-dpub-aria-1.0-20150707/">First
 						Public Working Draft</a></h2>
 				<ul>
-					<li>10-Mar-2016: Updated superclass role to <rref>img</rref> for <rref>doc-cover</rref> and revised the
-						definition to be specific it applies to an image.</li>
-					<li>3-Mar-2016: Changed name of doc-locator to <rref>doc-backlink</rref>.</li>
-					<li>2-Mar-2016: Updated superclass role to <rref>section</rref> for <rref>doc-abstract</rref>,
-							<rref>doc-colophon</rref>, <rref>doc-credit</rref>, <rref>doc-dedication</rref>,
-							<rref>doc-epigraph</rref>, <rref>doc-example</rref> and <rref>doc-footnote</rref>. Changed
-						superclass role to <rref>landmark</rref> for <rref>doc-part</rref>. Removed doc-title as
-							<rref>aria-labelledby</rref> is sufficient for labelling components.</li>
-					<li>1-Mar-2016: Removed doc-footnotes and added <rref>doc-endnote</rref> and <rref>doc-endnotes</rref> to
-						handle structural differences between standalone footnotes and lists of endnotes. Changed superclass
-						role to <rref>landmark</rref> for <rref>doc-bibliography</rref> and added guidance about using
-							<rref>doc-biblioentry</rref> with lists.</li>
-					<li>8-Nov-2015: Updated superclass role to <rref>group</rref> for <rref>doc-abstract</rref>,
-							<rref>doc-footnote</rref> and <rref>doc-qna</rref>.</li>
-					<li>12-Oct-2015: Changed the "dpub-" prefix on all roles to "doc-".</li>
-					<li>30-Sept-2015: Removed the glossterm and glossdef roles. These are replaced by <rref>term</rref> and
-							<rref>definition</rref> in [[WAI-ARIA]].</li>
-					<li>22-Sept-2015: Added the following new roles: <rref>doc-acknowledgments</rref>,
-							<rref>doc-colophon</rref>, <rref>doc-conclusion</rref>, <rref>doc-credit</rref>,
-							<rref>doc-credits</rref>, <rref>doc-dedication</rref>, <rref>doc-epigraph</rref>,
-							<rref>doc-errata</rref>, <rref>doc-example</rref> and <rref>doc-introduction</rref>.</li>
 				</ul>
-			</section>
+			</section> -->
 		</section>
 		<section class="appendix informative section" id="acknowledgements">
 			<h3>Acknowledgments</h3>

--- a/index.html
+++ b/index.html
@@ -3859,7 +3859,7 @@
 						the inability of them to be recognized as children of <rref>list</rref>.</li>
 				</ul>
 			</section>
-			<!-- <section>
+			<!--  <section>
 				<h2>Other substantive changes since the <a href="http://www.w3.org/TR/2015/WD-dpub-aria-1.0-20150707/">First
 						Public Working Draft</a></h2>
 				<ul>

--- a/index.html
+++ b/index.html
@@ -2990,7 +2990,12 @@
 							</tr>
 							<tr>
 								<th class="role-namefrom-head" scope="row">Name From:</th>
-								<td class="role-namefrom">author</td>
+								<td class="role-namefrom">
+									<ul>
+										<li>contents</li>
+										<li>author</li>
+									</ul>
+								</td>
 							</tr>
 							<tr>
 								<th class="role-namerequired-head" scope="row">Accessible Name Required:</th>


### PR DESCRIPTION
This PR fixes #15 by making the following changes:

- Adds the "[Deprecated in DPUB-ARIA 1.1]" label to the start of the definitions for doc-biblioentry and doc-endnote per the precedent for the directory role in ARIA 1.2
- Adds a note to each role explaining why it has been deprecated and to use list/listitem when html lists can't be used (and that a doc-footnote can be embedded in the list item in place of endnote).
- Removes the paragraphs that required these roles to be children of a list, as it doesn't make sense to leave invalid guidance.
- Removes required parent relationships from the roles and also removes them as required child roles from doc-bibliography and doc-endnotes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/22.html" title="Last updated on Sep 15, 2020, 8:19 PM UTC (c20b561)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/22/f56f781...c20b561.html" title="Last updated on Sep 15, 2020, 8:19 PM UTC (c20b561)">Diff</a>