### PR TITLE
Change superclass of doc-example to figure

### DIFF
--- a/index.html
+++ b/index.html
@@ -3880,41 +3880,20 @@
 		<section class="appendix informative" id="changelog">
 			<h2>Change Log</h2>
 			<section>
-				<h2>Substantive changes since the <a href="https://www.w3.org/TR/2016/WD-dpub-aria-1.0-20160317/">last
-						public working draft</a></h2>
+				<h2>Substantive changes since the <a href="https://www.w3.org/TR/dpub-aria-1.0/">DPUB-ARIA 1.0
+					Recommendation</a></h2>
 				<ul>
 					<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
-					<li>29-Sept-2016: Updated <rref>doc-index</rref> to inherit from <rref>navigation</rref> role and changed
-						"Name from" calculation to "author".</li>
+					<li>24-July-2020: Changed the superclass of <rref>doc-example</rref> to <rref>figure</rref> to
+							make compatible with use on HTML figure.</li>
 				</ul>
 			</section>
-			<section>
+			<!--  <section>
 				<h2>Other substantive changes since the <a href="http://www.w3.org/TR/2015/WD-dpub-aria-1.0-20150707/">First
 						Public Working Draft</a></h2>
 				<ul>
-					<li>10-Mar-2016: Updated superclass role to <rref>img</rref> for <rref>doc-cover</rref> and revised the
-						definition to be specific it applies to an image.</li>
-					<li>3-Mar-2016: Changed name of doc-locator to <rref>doc-backlink</rref>.</li>
-					<li>2-Mar-2016: Updated superclass role to <rref>section</rref> for <rref>doc-abstract</rref>,
-							<rref>doc-colophon</rref>, <rref>doc-credit</rref>, <rref>doc-dedication</rref>,
-							<rref>doc-epigraph</rref>, <rref>doc-example</rref> and <rref>doc-footnote</rref>. Changed
-						superclass role to <rref>landmark</rref> for <rref>doc-part</rref>. Removed doc-title as
-							<rref>aria-labelledby</rref> is sufficient for labelling components.</li>
-					<li>1-Mar-2016: Removed doc-footnotes and added <rref>doc-endnote</rref> and <rref>doc-endnotes</rref> to
-						handle structural differences between standalone footnotes and lists of endnotes. Changed superclass
-						role to <rref>landmark</rref> for <rref>doc-bibliography</rref> and added guidance about using
-							<rref>doc-biblioentry</rref> with lists.</li>
-					<li>8-Nov-2015: Updated superclass role to <rref>group</rref> for <rref>doc-abstract</rref>,
-							<rref>doc-footnote</rref> and <rref>doc-qna</rref>.</li>
-					<li>12-Oct-2015: Changed the "dpub-" prefix on all roles to "doc-".</li>
-					<li>30-Sept-2015: Removed the glossterm and glossdef roles. These are replaced by <rref>term</rref> and
-							<rref>definition</rref> in [[WAI-ARIA]].</li>
-					<li>22-Sept-2015: Added the following new roles: <rref>doc-acknowledgments</rref>,
-							<rref>doc-colophon</rref>, <rref>doc-conclusion</rref>, <rref>doc-credit</rref>,
-							<rref>doc-credits</rref>, <rref>doc-dedication</rref>, <rref>doc-epigraph</rref>,
-							<rref>doc-errata</rref>, <rref>doc-example</rref> and <rref>doc-introduction</rref>.</li>
 				</ul>
-			</section>
+			</section> -->
 		</section>
 		<section class="appendix informative section" id="acknowledgements">
 			<h3>Acknowledgments</h3>

--- a/index.html
+++ b/index.html
@@ -2043,10 +2043,10 @@
 					<rdef>doc-example</rdef>
 					<div class="role-description">
 						<p>An illustration of a key concept of the work, such as a code listing, case study or problem.</p>
-						<pre class="example highlight">&lt;aside role="doc-example"&gt;
-   &lt;h1&gt;Hello World!&lt;/h1&gt;
+						<pre class="example highlight">&lt;figure role="doc-example"&gt;
+   &lt;figcaption&gt;Example 1 &#8212; Hello World!&lt;/figcaption&gt;
    &#8230;
-&lt;/aside></pre>
+&lt;/figure></pre>
 					</div>
 					<table class="role-features">
 						<caption>Characteristics:</caption>
@@ -2063,7 +2063,7 @@
 							</tr>
 							<tr>
 								<th class="role-parent-head" scope="row">Superclass Role:</th>
-								<td class="role-parent"><rref>section</rref></td>
+								<td class="role-parent"><rref>figure</rref></td>
 							</tr>
 							<tr>
 								<th class="role-children-head" scope="row">Subclass Roles:</th>


### PR DESCRIPTION
Per #19 this PR updates the superclass role of doc-example to figure to make it compatible with the HTML figure element.

It also updates the example to show a more realistic use of a figure element for a code listing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/23.html" title="Last updated on Sep 15, 2020, 8:16 PM UTC (bf8cc21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/23/c7006a9...bf8cc21.html" title="Last updated on Sep 15, 2020, 8:16 PM UTC (bf8cc21)">Diff</a>