### PR TITLE
update doc-pagebreak definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,13 +81,13 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>Enabling users of assistive technologies to find their way through Web content requires embedding semantic
-				metadata about Web document structural divisions. This is particularly important for structural divisions of
-				long-form documents and goes along with embedding semantic metadata about Web-application widgets and
-				behaviors for assistive technologies. This specification defines a set of WAI-ARIA roles specific to helping
-				users of assistive technologies navigate through such long-form documents.</p>
-			<p>This document is part of the WAI-ARIA suite described in the <a href="http://www.w3.org/WAI/intro/aria.php"
-					>WAI-ARIA Overview</a>.</p>
+			<p>Enabling users of assistive technologies to find their way through Web content requires embedding
+				semantic metadata about Web document structural divisions. This is particularly important for structural
+				divisions of long-form documents and goes along with embedding semantic metadata about Web-application
+				widgets and behaviors for assistive technologies. This specification defines a set of WAI-ARIA roles
+				specific to helping users of assistive technologies navigate through such long-form documents.</p>
+			<p>This document is part of the WAI-ARIA suite described in the <a
+					href="http://www.w3.org/WAI/intro/aria.php">WAI-ARIA Overview</a>.</p>
 		</section>
 		<section id="sotd">
 			<p>The Candidate Recommendation exit criteria are listed in the <a href="#exit_criteria">appendix</a>.</p>
@@ -96,16 +96,16 @@
 		<section class="informative" id="introduction">
 			<h1>Introduction</h1>
 			<p><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is a technical specification that
-				defines a common host language semantic accessibility API and framework that enables web browsers to map the
-				accessibility semantics in web content to platform-specific accessibility APIs. This enables web content to
-				be interoperable with platform assistive technologies similar to native platform applications without
-				platform dependencies.</p>
+				defines a common host language semantic accessibility API and framework that enables web browsers to map
+				the accessibility semantics in web content to platform-specific accessibility APIs. This enables web
+				content to be interoperable with platform assistive technologies similar to native platform applications
+				without platform dependencies.</p>
 			<p>This specification is a modular extension of <abbr title="Accessible Rich Internet Applications"
 					>WAI-ARIA</abbr> designed for the digital publishing industry. The goals of this specification
 				include:</p>
 			<ul>
-				<li>Expanding [[WAI-ARIA]] to produce structural semantic extensions to accommodate the digital publishing
-					industry.</li>
+				<li>Expanding [[WAI-ARIA]] to produce structural semantic extensions to accommodate the digital
+					publishing industry.</li>
 				<li>Align with a new governance model for modularization and extensions to <abbr
 						title="Accessible Rich Internet Applications">WAI-ARIA</abbr>.</li>
 				<li>Provide structural semantics extensions that will support both assistive technologies and enable
@@ -114,14 +114,15 @@
 			<p>The roles defined in this specification are derived from the <a
 					href="https://idpf.github.io/epub-vocabs/structure/">EPUB Structural Semantics Vocabulary</a>.</p>
 			<p>For a more detailed explanation of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
-				please refer to the <a href="http://www.w3.org/WAI/intro/aria">WAI-ARIA Introduction</a> and how it applies
-				to Rich Internet Application Accessibility.</p>
+				please refer to the <a href="http://www.w3.org/WAI/intro/aria">WAI-ARIA Introduction</a> and how it
+				applies to Rich Internet Application Accessibility.</p>
 
 			<section id="target-audience">
 				<h2>Target Audience</h2>
 				<p>This specification defines a module of <abbr title="Accessible Rich Internet Applications"
-						>WAI-ARIA</abbr> for digital publishing, including <a data-lt="role">roles</a>, <a data-lt="state"
-						>states</a>, <a data-lt="property">properties</a> and values. It impacts several audiences:</p>
+						>WAI-ARIA</abbr> for digital publishing, including <a data-lt="role">roles</a>, <a
+						data-lt="state">states</a>, <a data-lt="property">properties</a> and values. It impacts several
+					audiences:</p>
 				<ul>
 					<li><a data-lt="user agent">User agents</a> that process content containing <abbr
 							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Digital Publishing <abbr
@@ -131,15 +132,16 @@
 					<li>Authors of digital publications;</li>
 					<li>Authoring tools that help authors create conforming digital publications; and</li>
 					<li>Conformance checkers, that verify appropriate use of <abbr
-							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and this Digital Publishing <abbr
-							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module.</li>
+							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and this Digital Publishing
+							<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module.</li>
 				</ul>
 				<p>Each conformance requirement indicates the audience to which it applies.</p>
-				<p>Although this specification is applicable to the above audiences, it is not specifically targeted to, nor
-					is it intended to be the sole source of information for, any of these audiences. In the future,
+				<p>Although this specification is applicable to the above audiences, it is not specifically targeted to,
+					nor is it intended to be the sole source of information for, any of these audiences. In the future,
 					additional documents will be created to assist authors in applying these <abbr
-						title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics for the publishing industry
-					and to define how the information in this document is mapped to platform accessibility APIs.</p>
+						title="Accessible Rich Internet Applications">WAI-ARIA</abbr> semantics for the publishing
+					industry and to define how the information in this document is mapped to platform accessibility
+					APIs.</p>
 			</section>
 
 			<section id="ua-support">
@@ -152,66 +154,68 @@
 			<section id="co-evolution">
 				<h2>Co-Evolution of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Host
 					Languages</h2>
-				<p>The Digital Publishing <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module follows
-					the model for <a href="http://www.w3.org/TR/wai-aria-1.1/#co-evolution">co-evolution of <abbr
-							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and host languages</a> defined in
-					[[WAI-ARIA]]. It is intended to augment semantics in supporting languages like [[HTML5]], [[SVG2]] and
-					EPUB, or to be used as an accessibility enhancement technology in other markup-based languages that do
-					not explicitly include support for ARIA. It clarifies semantics to assistive technologies when authors
-					create new types of objects, via style and script, that are not yet directly supported by the language of
-					the page, because the invention of new types of objects is faster than standardized support for them
-					appears in web languages.</p>
-				<p>It is not appropriate to create objects with style and script when the host language provides a semantic
-					element for that type of objects. While <abbr title="Accessible Rich Internet Applications"
-						>WAI-ARIA</abbr> can improve the accessibility of these objects, accessibility is best provided by
-					allowing the user agent to handle the object natively. For example, it is not better to use a
-						<rref>heading</rref> role on a <code>div</code> element than it is to use a native heading element,
-					such as an <code>h1</code>.</p>
+				<p>The Digital Publishing <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module
+					follows the model for <a href="http://www.w3.org/TR/wai-aria-1.1/#co-evolution">co-evolution of
+							<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and host languages</a>
+					defined in [[WAI-ARIA]]. It is intended to augment semantics in supporting languages like [[HTML5]],
+					[[SVG2]] and EPUB, or to be used as an accessibility enhancement technology in other markup-based
+					languages that do not explicitly include support for ARIA. It clarifies semantics to assistive
+					technologies when authors create new types of objects, via style and script, that are not yet
+					directly supported by the language of the page, because the invention of new types of objects is
+					faster than standardized support for them appears in web languages.</p>
+				<p>It is not appropriate to create objects with style and script when the host language provides a
+					semantic element for that type of objects. While <abbr title="Accessible Rich Internet Applications"
+						>WAI-ARIA</abbr> can improve the accessibility of these objects, accessibility is best provided
+					by allowing the user agent to handle the object natively. For example, it is not better to use a
+						<rref>heading</rref> role on a <code>div</code> element than it is to use a native heading
+					element, such as an <code>h1</code>.</p>
 				<p>It is expected that, over time, host languages will evolve to provide semantics for objects that
-					currently can only be declared with this specification. This is natural and desirable, as one goal of
-						<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is to help stimulate the emergence
-					of more semantic and accessible markup. When native semantics for a given feature become available, it is
-					appropriate for authors to use the native feature and stop using this module for that feature. Legacy
-					content may continue to use the Digital Publishing <abbr title="Accessible Rich Internet Applications"
-						>WAI-ARIA</abbr> module, however, so the need for user agents to support it remains.</p>
+					currently can only be declared with this specification. This is natural and desirable, as one goal
+					of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> is to help stimulate the
+					emergence of more semantic and accessible markup. When native semantics for a given feature become
+					available, it is appropriate for authors to use the native feature and stop using this module for
+					that feature. Legacy content may continue to use the Digital Publishing <abbr
+						title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module, however, so the need for
+					user agents to support it remains.</p>
 				<p>While specific features of this module may lose importance over time, the general possibility of the
 					Digital Publishing <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module to add
-					semantics to web pages or open web based standards, such as EPUB, is expected to be a persistent need.
-					Host languages may not implement all the semantics this module provides, and various host languages may
-					implement different subsets of the features. New types of objects are continually being developed, and
-					one goal of this specification is to provide a way to make such objects accessible, because authoring
-					practices often advance faster than host language standards. In this way, this module and host languages
-					both evolve together but at different rates.</p>
-				<p>Some host languages exist to create semantics for features other than the user interface. For example,
-					SVG expresses the semantics behind production of graphical objects, not of user interface components that
-					those objects may represent. Host languages such as these might, by design, not provide native semantics
-					that map to this specification's features. In these cases, the Digital Publishing <abbr
-						title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module could be adopted as a long-term
-					approach to add semantic information to these host languages.</p>
+					semantics to web pages or open web based standards, such as EPUB, is expected to be a persistent
+					need. Host languages may not implement all the semantics this module provides, and various host
+					languages may implement different subsets of the features. New types of objects are continually
+					being developed, and one goal of this specification is to provide a way to make such objects
+					accessible, because authoring practices often advance faster than host language standards. In this
+					way, this module and host languages both evolve together but at different rates.</p>
+				<p>Some host languages exist to create semantics for features other than the user interface. For
+					example, SVG expresses the semantics behind production of graphical objects, not of user interface
+					components that those objects may represent. Host languages such as these might, by design, not
+					provide native semantics that map to this specification's features. In these cases, the Digital
+					Publishing <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> module could be
+					adopted as a long-term approach to add semantic information to these host languages.</p>
 			</section>
 
 			<section id="authoring_practices">
 				<h2>Authoring Practices</h2>
 				<section id="authoring_tools">
 					<h3>Authoring Tools</h3>
-					<p>Many of the requirements in the definitions of the <abbr title="Accessible Rich Internet Applications"
-							>WAI-ARIA</abbr> and Digital Publishing <abbr title="Accessible Rich Internet Applications"
-							>WAI-ARIA</abbr>
-						<a data-lt="role">roles</a>, <a data-lt="state">states</a> and <a data-lt="property">properties</a>
-						can be checked automatically during the development process, similar to other quality control
-						processes used for validating code. To assist authors who are creating digital publications, such as
-						EPUB, can compare the semantic structure of Digital Publishing <abbr
-							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles from the <abbr
-							title="Document Object Model">DOM</abbr> to that defined in this specification and notify the
-						author of errors or simply create templates that enforce that structure.</p>
+					<p>Many of the requirements in the definitions of the <abbr
+							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Digital Publishing <abbr
+							title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
+						<a data-lt="role">roles</a>, <a data-lt="state">states</a> and <a data-lt="property"
+							>properties</a> can be checked automatically during the development process, similar to
+						other quality control processes used for validating code. To assist authors who are creating
+						digital publications, such as EPUB, can compare the semantic structure of Digital Publishing
+							<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles from the <abbr
+							title="Document Object Model">DOM</abbr> to that defined in this specification and notify
+						the author of errors or simply create templates that enforce that structure.</p>
 				</section>
 
 				<section id="authoring_testing">
 					<h3>Testing Practices and Tools</h3>
-					<p>The accessibility of interactive content cannot be confirmed by static checks alone. Developers of
-						interactive content should test for device-independent access to <a data-lt="widget">widgets</a> and
-						applications, and should verify accessibility <abbr title="application programing interface"
-							>API</abbr> access to all content and changes during user interaction.</p>
+					<p>The accessibility of interactive content cannot be confirmed by static checks alone. Developers
+						of interactive content should test for device-independent access to <a data-lt="widget"
+							>widgets</a> and applications, and should verify accessibility <abbr
+							title="application programing interface">API</abbr> access to all content and changes during
+						user interaction.</p>
 				</section>
 			</section>
 
@@ -224,13 +228,13 @@
 		</section>
 		<section class="normative" id="conformance">
 			<p>This specification indicates whether a section is <a>normative</a> or <a>informative</a>. Classifying a
-				section as normative or informative applies to the entire section. A statement "This section is normative"
-				or "This section is informative" applies to all sub-sections of that section.</p>
-			<p>Normative sections provide requirements that authors, user agents and assistive technologies MUST follow for
-				an implementation to conform to this specification.</p>
+				section as normative or informative applies to the entire section. A statement "This section is
+				normative" or "This section is informative" applies to all sub-sections of that section.</p>
+			<p>Normative sections provide requirements that authors, user agents and assistive technologies MUST follow
+				for an implementation to conform to this specification.</p>
 			<p>Informative sections provide information useful to understanding the specification. Such sections may
-				contain examples of recommended practice, but it is not required to follow such recommendations in order to
-				conform to this specification.</p>
+				contain examples of recommended practice, but it is not required to follow such recommendations in order
+				to conform to this specification.</p>
 		</section>
 		<section class="informative" id="terms">
 			<h1>Important Terms</h1>
@@ -240,8 +244,9 @@
 			<h1>Digital Publishing Roles</h1>
 			<p>This section defines additions to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
 				<a>role</a>
-				<a>taxonomy</a> and describes the characteristics and properties of all <a data-lt="role">roles</a>. See <a
-					href="#roles" class="specref">ARIA Roles</a> for descriptions of the fields provided by this module.</p>
+				<a>taxonomy</a> and describes the characteristics and properties of all <a data-lt="role">roles</a>. See
+					<a href="#roles" class="specref">ARIA Roles</a> for descriptions of the fields provided by this
+				module.</p>
 			<section id="role_definitions">
 				<h2>Definition of Roles</h2>
 				<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
@@ -250,8 +255,8 @@
 				<div class="role">
 					<rdef>doc-abstract</rdef>
 					<div class="role-description">
-						<p>A short summary of the principal ideas, concepts and conclusions of the work, or of a section or
-							excerpt within it.</p>
+						<p>A short summary of the principal ideas, concepts and conclusions of the work, or of a section
+							or excerpt within it.</p>
 						<pre class="example highlight">&lt;section role="doc-abstract" aria-label="Abstract"&gt;
    &lt;p&gt;Accessibility of web content requires semantic information about widgets, structures,
       and behaviors &#8230;&lt;/p&gt;
@@ -284,8 +289,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#abstract"
-										>abstract</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#abstract">abstract</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -371,8 +377,8 @@
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
 								<td class="role-related">EPUB <a
-										href="https://idpf.github.io/epub-vocabs/structure/#acknowledgments">acknowledgments</a>
-									[[EPUB-SSV]]</td>
+										href="https://idpf.github.io/epub-vocabs/structure/#acknowledgments"
+										>acknowledgments</a> [[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -424,9 +430,9 @@
 				<div class="role">
 					<rdef>doc-afterword</rdef>
 					<div class="role-description">
-						<p>A closing statement from the author or a person of importance, typically providing insight into how
-							the content came to be written, its significance, or related events that have transpired since its
-							timeline.</p>
+						<p>A closing statement from the author or a person of importance, typically providing insight
+							into how the content came to be written, its significance, or related events that have
+							transpired since its timeline.</p>
 						<pre class="example highlight">&lt;section role="doc-afterword"&gt;
    &lt;h1&gt;Afterword: Why I Wrote This Book&lt;/h1&gt;
    &#8230;
@@ -459,8 +465,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#afterword"
-										>afterword</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#afterword">afterword</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -512,8 +519,8 @@
 				<div class="role">
 					<rdef>doc-appendix</rdef>
 					<div class="role-description">
-						<p>A section of supplemental information located after the primary content that informs the content
-							but is not central to it.</p>
+						<p>A section of supplemental information located after the primary content that informs the
+							content but is not central to it.</p>
 						<pre class="example highlight">&lt;section role="doc-appendix"&gt;
    &lt;h1&gt;Appendix A. Historical Timeline&lt;/h1&gt;
    &#8230;
@@ -546,8 +553,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#appendix"
-										>appendix</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#appendix">appendix</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -599,8 +607,8 @@
 				<div class="role">
 					<rdef>doc-backlink</rdef>
 					<div class="role-description">
-						<p>A link that allows the user to return to a related location in the content (e.g., from a footnote
-							to its reference or from a glossary definition to where a term is used).</p>
+						<p>A link that allows the user to return to a related location in the content (e.g., from a
+							footnote to its reference or from a glossary definition to where a term is used).</p>
 						<pre class="example highlight">&lt;aside id="fn01" role="doc-footnote"&gt;
    &lt;a role="doc-backlink" href="#fnref01"&gt;1.&lt;/a&gt;
    Additional results of this study and
@@ -634,8 +642,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#backlink"
-										>referrer</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#backlink">referrer</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -692,11 +701,11 @@
 				<div class="role">
 					<rdef>doc-biblioentry</rdef>
 					<div class="role-description">
-						<p>A single reference to an external source in a bibliography. A biblioentry typically provides more
-							detailed information than its reference(s) in the content (e.g., full title, author(s), publisher,
-							publication date, etc.).</p>
-						<p>Authors MUST ensure that <a>elements</a> with role <code>doc-biblioentry</code> are contained in,
-							or owned, by an element with the role <rref>list</rref>.</p>
+						<p>A single reference to an external source in a bibliography. A biblioentry typically provides
+							more detailed information than its reference(s) in the content (e.g., full title, author(s),
+							publisher, publication date, etc.).</p>
+						<p>Authors MUST ensure that <a>elements</a> with role <code>doc-biblioentry</code> are contained
+							in, or owned, by an element with the role <rref>list</rref>.</p>
 						<pre class="example highlight">&lt;section role="doc-bibliography"&gt;
    &lt;h1&gt;Cited Works&lt;/h1&gt;
    &lt;div role="list"&gt;
@@ -797,7 +806,8 @@
 				<div class="role">
 					<rdef>doc-bibliography</rdef>
 					<div class="role-description">
-						<p>A list of external references cited in the work, which may be to print or digital sources.</p>
+						<p>A list of external references cited in the work, which may be to print or digital
+							sources.</p>
 						<pre class="example highlight">&lt;section role="doc-bibliography"&gt;
    &lt;h1&gt;Select Bibliography&lt;/h1&gt;
    &lt;ul&gt;
@@ -833,8 +843,8 @@
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
 								<td class="role-related">EPUB <a
-										href="https://idpf.github.io/epub-vocabs/structure/#bibliography">bibliography</a>
-									[[EPUB-SSV]]</td>
+										href="https://idpf.github.io/epub-vocabs/structure/#bibliography"
+										>bibliography</a> [[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -920,8 +930,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#biblioref"
-										>biblioref</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#biblioref">biblioref</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1011,8 +1022,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#chapter"
-										>chapter</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#chapter">chapter</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1064,8 +1076,8 @@
 				<div class="role">
 					<rdef>doc-colophon</rdef>
 					<div class="role-description">
-						<p>A short section of production notes particular to the edition (e.g., describing the typeface used),
-							often located at the end of a work.</p>
+						<p>A short section of production notes particular to the edition (e.g., describing the typeface
+							used), often located at the end of a work.</p>
 						<pre class="example highlight">&lt;section role="doc-colophon" aria-label="About the type"&gt;
    &lt;p&gt;This publication was set using &#8230; &lt;/p&gt;
 &lt;/section></pre>
@@ -1097,8 +1109,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#colophon"
-										>colophon</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#colophon">colophon</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1183,8 +1196,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#conclusion"
-										>conclusion</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#conclusion">conclusion</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1236,7 +1250,8 @@
 				<div class="role">
 					<rdef>doc-cover</rdef>
 					<div class="role-description">
-						<p>An image that sets the mood or tone for the work and typically includes the title and author.</p>
+						<p>An image that sets the mood or tone for the work and typically includes the title and
+							author.</p>
 						<pre class="example highlight">&lt;img role="doc-cover" src="coverimage.jpg" alt="A Room of One's Own by Virginia Woolf"/&gt;</pre>
 					</div>
 					<table class="role-features">
@@ -1266,8 +1281,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#cover"
-										>cover</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#cover">cover</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1319,8 +1335,8 @@
 				<div class="role">
 					<rdef>doc-credit</rdef>
 					<div class="role-description">
-						<p>An acknowledgment of the source of integrated content from third-party sources, such as photos.
-							Typically identifies the creator, copyright and any restrictions on reuse.</p>
+						<p>An acknowledgment of the source of integrated content from third-party sources, such as
+							photos. Typically identifies the creator, copyright and any restrictions on reuse.</p>
 						<pre class="example highlight">&lt;p role="doc-credit"&gt;
    Page 62, Table 3.1 from &lt;cite&gt;“Economic Foundations of Cost-Effectiveness Analysis”&lt;/cite&gt;
    by A. M. Garber and C. E. Phelps &#8230;
@@ -1353,8 +1369,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#credit"
-										>credit</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#credit">credit</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1439,8 +1456,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#credits"
-										>credits</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#credits">credits</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1492,8 +1510,8 @@
 				<div class="role">
 					<rdef>doc-dedication</rdef>
 					<div class="role-description">
-						<p>An inscription at the front of the work, typically addressed in tribute to one or more persons
-							close to the author.</p>
+						<p>An inscription at the front of the work, typically addressed in tribute to one or more
+							persons close to the author.</p>
 						<pre class="example highlight">&lt;p role="doc-dedication"&gt;To my family, without whom this would have never been possible.&lt;/p&gt;</pre>
 					</div>
 					<table class="role-features">
@@ -1523,8 +1541,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#dedication"
-										>dedication</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#dedication">dedication</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1576,11 +1595,11 @@
 				<div class="role">
 					<rdef>doc-endnote</rdef>
 					<div class="role-description">
-						<p>One of a collection of notes that occur at the end of a work, or a section within it, that provides
-							additional context to a referenced passage of text.</p>
+						<p>One of a collection of notes that occur at the end of a work, or a section within it, that
+							provides additional context to a referenced passage of text.</p>
 						<p>Authors MUST ensure that <a>elements</a> with <a>role</a>
 							<code>doc-endnote</code> are contained in, or owned, by an element with the role
-							<rref>list</rref>.</p>
+								<rref>list</rref>.</p>
 						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
    &lt;h2&gt;Notes&lt;/h2&gt;
    &lt;ol&gt;
@@ -1631,8 +1650,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#rearnote"
-										>rearnote</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#rearnote">rearnote</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1686,8 +1706,8 @@
 					<div class="role-description">
 						<p>A collection of notes at the end of a work or a section within it.</p>
 						<p>Note that the <code>doc-endnotes</code>
-							<a>role</a> is never applied directly to the list of endnotes. See the <rref>doc-endnote</rref>
-							role for more information.</p>
+							<a>role</a> is never applied directly to the list of endnotes. See the
+								<rref>doc-endnote</rref> role for more information.</p>
 						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
    &lt;h2&gt;Notes&lt;/h2&gt;
    &lt;ol&gt;
@@ -1724,8 +1744,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#rearnotes"
-										>rearnotes</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#rearnotes">rearnotes</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1811,8 +1832,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#epigraph"
-										>epigraph</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#epigraph">epigraph</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1864,8 +1886,8 @@
 				<div class="role">
 					<rdef>doc-epilogue</rdef>
 					<div class="role-description">
-						<p>A concluding section of narrative that wraps up or comments on the actions and events of the work,
-							typically from a future perspective.</p>
+						<p>A concluding section of narrative that wraps up or comments on the actions and events of the
+							work, typically from a future perspective.</p>
 						<pre class="example highlight">&lt;section role="doc-epilogue"&gt;
    &lt;header&gt;
       &lt;h1&gt;Epilogue&lt;/h1&gt;
@@ -1902,8 +1924,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#epilogue"
-										>epilogue</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#epilogue">epilogue</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -1955,8 +1978,8 @@
 				<div class="role">
 					<rdef>doc-errata</rdef>
 					<div class="role-description">
-						<p>A set of corrections discovered after initial publication of the work, sometimes referred to as
-							corrigenda.</p>
+						<p>A set of corrections discovered after initial publication of the work, sometimes referred to
+							as corrigenda.</p>
 						<pre class="example highlight">&lt;section role="doc-errata"&gt;
    &lt;h1&gt;Corrections&lt;/h1&gt;
    &#8230;
@@ -1989,8 +2012,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#errata"
-										>errata</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#errata">errata</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2042,7 +2066,8 @@
 				<div class="role">
 					<rdef>doc-example</rdef>
 					<div class="role-description">
-						<p>An illustration of a key concept of the work, such as a code listing, case study or problem.</p>
+						<p>An illustration of a key concept of the work, such as a code listing, case study or
+							problem.</p>
 						<pre class="example highlight">&lt;aside role="doc-example"&gt;
    &lt;h1&gt;Hello World!&lt;/h1&gt;
    &#8230;
@@ -2127,11 +2152,12 @@
 				<div class="role">
 					<rdef>doc-footnote</rdef>
 					<div class="role-description">
-						<p>Ancillary information, such as a citation or commentary, that provides additional context to a
-							referenced passage of text.</p>
+						<p>Ancillary information, such as a citation or commentary, that provides additional context to
+							a referenced passage of text.</p>
 						<p>The <code>doc-footnote</code>
-							<a>role</a> is only for representing individual notes that occur within the body of a work. For
-							collections of notes that occur at the end of a section, see <rref>doc-endnotes</rref>.</p>
+							<a>role</a> is only for representing individual notes that occur within the body of a work.
+							For collections of notes that occur at the end of a section, see
+							<rref>doc-endnotes</rref>.</p>
 						<pre class="example highlight">&lt;aside id="6baa07af" role="doc-footnote"&gt;
    * Additional results of this study and similar studies can be found at &#8230;
 &lt;/aside&gt;</pre>
@@ -2163,8 +2189,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#footnote"
-										>footnote</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#footnote">footnote</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2250,8 +2277,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#foreword"
-										>foreword</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#foreword">foreword</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2343,8 +2371,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#glossary"
-										>glossary</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#glossary">glossary</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2429,8 +2458,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#glossref"
-										>glossref</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#glossref">glossref</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2530,8 +2560,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#index"
-										>index</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#index">index</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2616,8 +2647,8 @@
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
 								<td class="role-related">EPUB <a
-										href="https://idpf.github.io/epub-vocabs/structure/#introduction">introduction</a>
-									[[EPUB-SSV]]</td>
+										href="https://idpf.github.io/epub-vocabs/structure/#introduction"
+										>introduction</a> [[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2752,8 +2783,8 @@
 				<div class="role">
 					<rdef>doc-noteref</rdef>
 					<div class="role-description">
-						<p>A reference to a footnote or endnote, typically appearing as a superscripted number or symbol in
-							the main body of text.</p>
+						<p>A reference to a footnote or endnote, typically appearing as a superscripted number or symbol
+							in the main body of text.</p>
 						<pre class="example highlight">&lt;p&gt; &#8230; as studies have shown.&lt;a href="#fn01" id="fnref01" role="doc-noteref"&gt;[1]&lt;/a&gt;&lt;/p&gt;</pre>
 					</div>
 					<table class="role-features">
@@ -2783,8 +2814,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#noteref"
-										>noteref</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#noteref">noteref</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2881,8 +2913,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#notice"
-										>notice</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#notice">notice</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -2934,16 +2967,26 @@
 				<div class="role">
 					<rdef>doc-pagebreak</rdef>
 					<div class="role-description">
-						<p>A separator denoting the position before which a break occurs between two contiguous pages in a
-							statically paginated version of the content.</p>
-						<p>Page break locators are also commonly used to provide static markers in purely digital publications
-							(i.e., where no statically paginated equivalent exists). These markers provide consistent
-							navigation regardless of differences in font and screen size that can otherwise affect the dynamic
-							pagination of the content.</p>
+						<p>A separator denoting the position before which a break occurs between two contiguous pages in
+							a statically paginated version of the content.</p>
+						<p>Page break locators are also commonly used to provide static markers in purely digital
+							publications (i.e., where no statically paginated equivalent exists). These markers provide
+							consistent navigation regardless of differences in font and screen size that can otherwise
+							affect the dynamic pagination of the content.</p>
 						<p>The name of the page break SHOULD be an end user-consumable page number so that assistive
 							technologies can announce the page as needed (e.g., in a command to indentify the current
 							page).</p>
-						<pre class="example highlight">&lt;hr id="pg04" role="doc-pagebreak" aria-label="4"/&gt;</pre>
+						<aside class="example">
+							<p>The following example shows three equivalent patterns for marking up page breaks in
+								digital publications. Either the <code>aria-label</code> or <code>title</code>
+								attributes can be used to assign the accessible name when an explicit page number is not
+								provided.</p>
+							<pre class="highlight">&lt;hr id="pg04" role="doc-pagebreak" aria-label="4"/&gt;
+
+&lt;span id="pg04" role="doc-pagebreak" title="4"/&gt;
+
+&lt;div id="pg04" role="doc-pagebreak"&gt;4&lt;/div></pre>
+						</aside>
 					</div>
 					<table class="role-features">
 						<caption>Characteristics:</caption>
@@ -2972,8 +3015,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#pagebreak"
-										>pagebreak</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#pagebreak">pagebreak</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3067,8 +3111,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#page-list"
-										>page-list</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#page-list">page-list</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3158,8 +3203,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#part"
-										>part</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#part">part</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3211,7 +3257,8 @@
 				<div class="role">
 					<rdef>doc-preface</rdef>
 					<div class="role-description">
-						<p>An introductory section that precedes the work, typically written by the author of the work.</p>
+						<p>An introductory section that precedes the work, typically written by the author of the
+							work.</p>
 						<pre class="example highlight">&lt;section role="doc-preface"&gt;
    &lt;h1&gt;Introduction:A Guide to the Galaxy&lt;/h1&gt;
    &#8230;
@@ -3244,8 +3291,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#preface"
-										>preface</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#preface">preface</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3297,7 +3345,8 @@
 				<div class="role">
 					<rdef>doc-prologue</rdef>
 					<div class="role-description">
-						<p>An introductory section that sets the background to a work, typically part of the narrative.</p>
+						<p>An introductory section that sets the background to a work, typically part of the
+							narrative.</p>
 						<pre class="example highlight">&lt;section role="doc-prologue"&gt;
    &lt;header&gt;
       &lt;h1&gt;Prologue&lt;/h1&gt;
@@ -3334,8 +3383,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#prologue"
-										>prologue</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#prologue">prologue</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3387,19 +3437,20 @@
 				<div class="role">
 					<rdef>doc-pullquote</rdef>
 					<div class="role-description">
-						<p>A distinctively placed or highlighted quotation from the current content designed to draw attention
-							to a topic or highlight a key point.</p>
-						<p>Unlike a passage quoted from another source, a pullquote is a direct repetition of text in the
-							current document. As a result, authors must ensure that the presentational occurrence is hidden
-							from users of assistive technologies (e.g., using the <pref>aria-hidden</pref> attribute).</p>
-						<p>The following example shows the identification of a pullquote that will be presented elsewhere
-							(e.g., via a script). In this case, the pullquote is not hidden as the marked text is not
-							presentational.</p>
+						<p>A distinctively placed or highlighted quotation from the current content designed to draw
+							attention to a topic or highlight a key point.</p>
+						<p>Unlike a passage quoted from another source, a pullquote is a direct repetition of text in
+							the current document. As a result, authors must ensure that the presentational occurrence is
+							hidden from users of assistive technologies (e.g., using the <pref>aria-hidden</pref>
+							attribute).</p>
+						<p>The following example shows the identification of a pullquote that will be presented
+							elsewhere (e.g., via a script). In this case, the pullquote is not hidden as the marked text
+							is not presentational.</p>
 						<pre class="example highlight">&lt;p>&#8230; I may die, but first you, my tyrant and tormentor, shall curse the sun that gazes on your misery.
    &lt;span id="pq01" role="doc-pullquote">Beware, for I am fearless and therefore powerful.&lt;/span>
    I will watch with the wiliness of a snake, that I may sting with its venom. &#8230; &lt;/p></pre>
-						<p>The next example shows a pullquote that duplicates the text. This quote is hidden because it is for
-							presentational purposes only.</p>
+						<p>The next example shows a pullquote that duplicates the text. This quote is hidden because it
+							is for presentational purposes only.</p>
 						<pre class="example highlight">&lt;p>&#8230; Better habits pave the way to growth, and growth leads to greater happiness.&lt;/p>
 &lt;aside role="doc-pullquote" aria-hidden="true"&gt;
    Better habits pave the way to growth, and growth leads to greater happiness.
@@ -3432,8 +3483,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#pullquote"
-										>pullquote</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#pullquote">pullquote</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3485,8 +3537,8 @@
 				<div class="role">
 					<rdef>doc-qna</rdef>
 					<div class="role-description">
-						<p>A section of content structured as a series of questions and answers, such as an interview or list
-							of frequently asked questions.</p>
+						<p>A section of content structured as a series of questions and answers, such as an interview or
+							list of frequently asked questions.</p>
 						<pre class="example highlight">&lt;section role="doc-qna"&gt;
    &lt;h2&gt;Interview with the Author&lt;/h2&gt;
    &lt;dl&gt;
@@ -3523,8 +3575,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#qna"
-										>qna</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#qna">qna</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3609,8 +3662,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#subtitle"
-										>subtitle</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#subtitle">subtitle</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3667,7 +3721,8 @@
 				<div class="role">
 					<rdef>doc-tip</rdef>
 					<div class="role-description">
-						<p>Helpful information that clarifies some aspect of the content or assists in its comprehension.</p>
+						<p>Helpful information that clarifies some aspect of the content or assists in its
+							comprehension.</p>
 						<pre class="example highlight">&lt;aside role="doc-tip"&gt;
    &lt;h3&gt;Tip&lt;/h3&gt;
    &lt;p&gt;You can assign a variable a new value that is the result
@@ -3701,8 +3756,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#help"
-										>help</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#help">help</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3754,8 +3810,9 @@
 				<div class="role">
 					<rdef>doc-toc</rdef>
 					<div class="role-description">
-						<p>A navigational aid that provides an ordered list of links to the major sectional headings in the
-							content. A table of contents may cover an entire work, or only a smaller section of it.</p>
+						<p>A navigational aid that provides an ordered list of links to the major sectional headings in
+							the content. A table of contents may cover an entire work, or only a smaller section of
+							it.</p>
 						<pre class="example highlight">&lt;nav role="doc-toc"&gt;
    &lt;h1&gt;Contents&lt;/h1&gt;
    &lt;ol role="directory"&gt;
@@ -3794,8 +3851,9 @@
 							</tr>
 							<tr>
 								<th class="role-related-head" scope="row">Related Concepts:</th>
-								<td class="role-related">EPUB <a href="https://idpf.github.io/epub-vocabs/structure/#toc"
-										>toc</a> [[EPUB-SSV]]</td>
+								<td class="role-related">EPUB <a
+										href="https://idpf.github.io/epub-vocabs/structure/#toc">toc</a>
+									[[EPUB-SSV]]</td>
 							</tr>
 							<tr>
 								<th class="role-scope-head" scope="row">Required Context Role:</th>
@@ -3853,8 +3911,8 @@
 		<section class="appendix informative" id="a_schemata">
 			<h1>Schemata</h1>
 			<p>The <a href="http://www.w3.org/html/wg/">HTML Working Group</a> has incorporated the WAI-ARIA attributes
-				into <a href="http://www.w3.org/TR/html5/">HTML 5</a>. Official support for WAI-ARIA in HTML is provided in
-				that specification.</p>
+				into <a href="http://www.w3.org/TR/html5/">HTML 5</a>. Official support for WAI-ARIA in HTML is provided
+				in that specification.</p>
 			<p class="note">Validation support for the roles defined in this module will be added once the specification
 				reaches recommendation.</p>
 			<p>For information on incorporating WAI-ARIA into other grammars, refer to <a
@@ -3862,25 +3920,27 @@
 		</section>
 		<section class="appendix informative" id="exit_criteria">
 			<h1>Candidate Recommendation Exit Criteria</h1>
-			<p>For this specification to be advanced to Proposed Recommendation, it has to be proven that roles defined in
-				this specification have sufficient usage by the target communities. More specifically, it has to be
+			<p>For this specification to be advanced to Proposed Recommendation, it has to be proven that roles defined
+				in this specification have sufficient usage by the target communities. More specifically, it has to be
 				documented that <em>each</em>
-				<a href="#roles">Digital Publishing Role</a> is used (at least in preliminary prototypes, not necessarily in
-				full production yet) by two, independent document author/publisher as a means to structure document, where
-				“usage” means: </p>
+				<a href="#roles">Digital Publishing Role</a> is used (at least in preliminary prototypes, not
+				necessarily in full production yet) by two, independent document author/publisher as a means to
+				structure document, where “usage” means: </p>
 
 			<ul>
-				<li>the <code>role</code> attribute value is used, as defined in this specification; or, as a fallback</li>
+				<li>the <code>role</code> attribute value is used, as defined in this specification; or, as a
+					fallback</li>
 				<li>the <code>epub:type</code> attribute, defined for the purpose of <a
-						href="http://www.idpf.org/epub/31/spec/epub-contentdocs.html#sec-xhtml-semantic-inflection">Semantic
-						Inflection</a> in [[EPUB-Content]], is used with the related value (when specified in the detailed
-					specification of the role) in the <a href="https://idpf.github.io/epub-vocabs/structure/">EPUB Structural
-						Semantic Vocabulary</a> [[EPUB-SSV]]. </li>
+						href="http://www.idpf.org/epub/31/spec/epub-contentdocs.html#sec-xhtml-semantic-inflection"
+						>Semantic Inflection</a> in [[EPUB-Content]], is used with the related value (when specified in
+					the detailed specification of the role) in the <a
+						href="https://idpf.github.io/epub-vocabs/structure/">EPUB Structural Semantic Vocabulary</a>
+					[[EPUB-SSV]]. </li>
 			</ul>
 
 			<p> In the case where the <code>epub:type</code> attribute is used, the author/publisher should also clearly
-				state that the plan is to replace <code>epub:type</code> by the ARIA <code>role</code> attribute when this
-				specification is published as a Recommendation. Furthermore, it is also required that at least two,
+				state that the plan is to replace <code>epub:type</code> by the ARIA <code>role</code> attribute when
+				this specification is published as a Recommendation. Furthermore, it is also required that at least two,
 				independent authors/publishers use a comprehensive, although not necessarily complete, set of
 					<code>role</code> attribute (as opposed to <code>epub:type</code>). </p>
 		</section>

--- a/index.html
+++ b/index.html
@@ -2936,7 +2936,14 @@
 					<div class="role-description">
 						<p>A separator denoting the position before which a break occurs between two contiguous pages in a
 							statically paginated version of the content.</p>
-						<pre class="example highlight">&lt;span id="pg04" role="doc-pagebreak" title="4"/&gt;</pre>
+						<p>Page break locators are also commonly used to provide static markers in purely digital publications
+							(i.e., where no statically paginated equivalent exists). These markers provide consistent
+							navigation regardless of differences in font and screen size that can otherwise affect the dynamic
+							pagination of the content.</p>
+						<p>The name of the page break SHOULD be an end user-consumable page number so that assistive
+							technologies can announce the page as needed (e.g., in a command to indentify the current
+							page).</p>
+						<pre class="example highlight">&lt;hr id="pg04" role="doc-pagebreak" aria-label="4"/&gt;</pre>
 					</div>
 					<table class="role-features">
 						<caption>Characteristics:</caption>
@@ -3884,6 +3891,7 @@
 						Recommendation</a></h2>
 				<ul>
 					<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
+					<li>25-July-2020: Recommend that doc-pagebreak name be end user-consumable.</li>
 				</ul>
 			</section>
 			<!-- <section>


### PR DESCRIPTION
This PR makes a couple of changes to the doc-pagebreak definition:

- adds a new paragraph explaining use for purely digital publications (i.e., no static equivalent). Better aligns with the forthcoming WCAG SC.
- adds a recommendation for an end user-consumable name per issue #12 
- changes the example from a span to hr and changes title to aria-label


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/24.html" title="Last updated on Jul 27, 2020, 7:36 PM UTC (5bb98d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/24/3847bd6...5bb98d0.html" title="Last updated on Jul 27, 2020, 7:36 PM UTC (5bb98d0)">Diff</a>