### PR TITLE
Remove term and definition as required children of glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -2304,6 +2304,8 @@
 					<rdef>doc-glossary</rdef>
 					<div class="role-description">
 						<p>A brief dictionary of new, uncommon or specialized terms used in the content.</p>
+						<p>The structure of a glossary SHOULD make it possible for end users to identify each term and
+							associated definition (e.g., using the [[HTML]] <code>dl</code> or <code>dfn</code> elements).</p>
 						<pre class="example highlight">&lt;section role="doc-glossary" aria-label="glossary"&gt;
    &lt;dl&gt;
       &#8230;
@@ -2314,6 +2316,13 @@
       &lt;/dd&gt;
       &#8230;
    &lt;/dl&gt;
+&lt;/section&gt;</pre>
+						<pre class="example highlight">&lt;section role="doc-glossary" aria-labelledby="glosshd"&gt;
+   &lt;h2 id="glosshd">Glossay of Technical Terms&lt;/h2>
+   &lt;ul&gt;
+      &lt;li id="gtt00110001">&lt;dfn>algorithm&lt;/dfn> A set of rules &#8230;&lt;/li>
+      &#8230;
+   &lt;/ul&gt;
 &lt;/section&gt;</pre>
 					</div>
 					<table class="role-features">
@@ -2352,7 +2361,7 @@
 							</tr>
 							<tr>
 								<th class="role-mustcontain-head" scope="row">Required Owned Elements:</th>
-								<td class="role-mustcontain"><rref>term</rref>, <rref>definition</rref></td>
+								<td class="role-mustcontain"> </td>
 							</tr>
 							<tr>
 								<th class="role-required-properties-head">Required States and Properties:</th>


### PR DESCRIPTION
As noted in my comment in #9, this PR removes term and definition as required owned elements of glossary due to the pending redefinition of what that means (i.e., they must be direct children or the elements in between cannot have roles).

I've replaced this with a "should" in the definition that terms and definitions be discoverable. I also added an example using a list item with `dfn`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/25.html" title="Last updated on Jul 31, 2020, 11:22 AM UTC (cbf7d89)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/25/3847bd6...cbf7d89.html" title="Last updated on Jul 31, 2020, 11:22 AM UTC (cbf7d89)">Diff</a>