### PR TITLE
Clarify requirement for the name of doc-pagebreak

### DIFF
--- a/index.html
+++ b/index.html
@@ -2988,9 +2988,9 @@
 							publications (i.e., where no statically paginated equivalent exists). These markers provide
 							consistent navigation regardless of differences in font and screen size that can otherwise
 							affect the dynamic pagination of the content.</p>
-						<p>The name of the page break SHOULD be an end user-consumable page number so that assistive
-							technologies can announce the page as needed (e.g., in a command to indentify the current
-							page).</p>
+						<p>Authors MUST ensure the name of the page break is an end user-consumable page number that
+							identifies the page that is beginning so that assistive technologies can announce the page
+							as needed (e.g., in a command to indentify the current page).</p>
 						<aside class="example">
 							<p>The following example shows three equivalent patterns for marking up page breaks in
 								digital publications. Either the <code>aria-label</code> or <code>title</code>
@@ -3962,6 +3962,8 @@
 						Recommendation</a></h3>
 				<ul>
 					<!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
+					<li>31-July-2020: Clarified that the name of <rref>doc-pagebreak</rref> is the page number of the
+						page that is beginning.</li>
 					<li>31-July-2020: Removed <rref>term</rref> and <rref>definition</rref> as required children of
 							<rref>doc-glossary</rref> to accommodate various ways glossaries can be constructed. See <a
 							href="https://github.com/w3c/dpub-aria/issues/9">issue 9</a>.</li>


### PR DESCRIPTION
Fixes #27 by requiring the name identify the page that is beginning.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/29.html" title="Last updated on Sep 25, 2020, 11:51 AM UTC (cb0d4a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/29/aac695d...cb0d4a4.html" title="Last updated on Sep 25, 2020, 11:51 AM UTC (cb0d4a4)">Diff</a>