### PR TITLE
update-respec

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<title>Digital Publishing WAI-ARIA Module 1.1</title>
 		<meta charset="UTF-8" />
-		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/script/resolveReferences.js" class="remove"></script>
 		<script src="common/biblio.js" class="remove" defer="defer"></script>
 		<script src="common/script/linkFix.js" class="remove"></script>
@@ -113,7 +113,7 @@
 					"REC": "https://www.w3.org/TR/wai-aria-practices-1.2/"
 				},
 				preProcess:[linkCrossReferences],
-				postProcess:[fixImportedRefs],
+				postProcess:[fixImportedRefs, ariaAttributeReferences],
 				definitionMap:[]
 			};</script>
 	</head>

--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/script/resolveReferences.js" class="remove"></script>
 		<script src="common/biblio.js" class="remove" defer="defer"></script>
-		<script src="common/script/linkFix.js" class="remove"></script>
+		<!-- <script src="common/script/linkFix.js" class="remove"></script> -->
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove" src="common/script/ariaChild.js"></script>
 		<script class="remove" src="common/script/roleInfo.js"></script>
 		<script class="remove">
 			var respecConfig = {
-				wg: "Publishing Working Group",
+				// wg: "Publishing Working Group",
 				specStatus: "ED",
 				shortName: "dpub-aria-1.1",
 				edDraftURI: "https://w3c.github.io/dpub-aria/",
@@ -47,10 +47,7 @@
 					w3cid: 21614,
 				}],
 				
-				wg: "Accessible Rich Internet Applications Working Group",
-				wgURI: "https://www.w3.org/WAI/ARIA/",
-				wgPublicList: "public-aria",
-				wgPatentURI: "https://www.w3.org/2004/01/pp-impl/83726/status",
+				group: "aria",
 				
 				otherLinks:[ {
 					key: "Repository",
@@ -113,8 +110,9 @@
 					"REC": "https://www.w3.org/TR/wai-aria-practices-1.2/"
 				},
 				preProcess:[linkCrossReferences],
-				postProcess:[fixImportedRefs, ariaAttributeReferences],
-				definitionMap:[]
+				postProcess:[ariaAttributeReferences],
+				definitionMap:[],
+				xref: ["core-aam", "accname", "wai-aria"]
 			};</script>
 	</head>
 	<body>
@@ -269,21 +267,17 @@
 				contain examples of recommended practice, but it is not required to follow such recommendations in order
 				to conform to this specification.</p>
 		</section>
-		<section class="informative" id="terms">
-			<h2>Important Terms</h2>
-			<div data-include="common/terms.html" data-oninclude="restrictReferences"></div>
-		</section>
 		<section class="normative" id="roles">
 			<h2>Digital Publishing Roles</h2>
 			<p>This section defines additions to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
-				<a>role</a>
-				<a>taxonomy</a> and describes the characteristics and properties of all <a data-lt="role">roles</a>. See
+				<a class="termref">role</a>
+				<a class="termref">taxonomy</a> and describes the characteristics and properties of all <a data-lt="role" class="termref">roles</a>. See
 					<a href="#roles" class="specref">ARIA Roles</a> for descriptions of the fields provided by this
 				module.</p>
 			<section id="role_definitions">
 				<h3>Definition of Roles</h3>
 				<p>Below is an alphabetical list of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
-					<a data-lt="role">roles</a> to be used by rich internet application authors.</p>
+					<a data-lt="role" class="termref">roles</a> to be used by rich internet application authors.</p>
 				<p id="index_role">Placeholder for compact list of roles</p>
 				<div class="role">
 					<rdef>doc-abstract</rdef>
@@ -1618,7 +1612,7 @@
 							or a section within it, that provides additional context to a referenced passage of
 							text.</p>
 						<p class="note">The <code>doc-endnote</code>
-							<a>role</a> was designed for use as a list item, but due to clarifications in the WAI-ARIA
+							<a class="termref">role</a> was designed for use as a list item, but due to clarifications in the WAI-ARIA
 							specification, it is not valid as a child of the <rref>list</rref> role. As the
 								<rref>doc-endnotes</rref> role already identifies a section of endnotes, authors are
 							instead advised to use the <rref>list</rref> and <rref>listitem</rref> roles when native
@@ -1708,7 +1702,7 @@
 					<div class="role-description">
 						<p>A collection of notes at the end of a work or a section within it.</p>
 						<p>Note that the <code>doc-endnotes</code>
-							<a>role</a> is never applied directly to the list of endnotes.</p>
+							<a class="termref">role</a> is never applied directly to the list of endnotes.</p>
 						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
    &lt;h2&gt;Notes&lt;/h2&gt;
    &lt;ol&gt;
@@ -2160,7 +2154,7 @@
 						<p>Ancillary information, such as a citation or commentary, that provides additional context to
 							a referenced passage of text.</p>
 						<p>The <code>doc-footnote</code>
-							<a>role</a> is only for representing individual notes that occur within the body of a work.
+							<a class="termref">role</a> is only for representing individual notes that occur within the body of a work.
 							For collections of notes that occur at the end of a section, see
 							<rref>doc-endnotes</rref>.</p>
 						<pre class="example highlight">&lt;aside id="6baa07af" role="doc-footnote"&gt;
@@ -4188,10 +4182,5 @@
 			</section>
 			<div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
 		</section>
-		<p id="hack" hidden="hidden">This para is removed. It only exists to work around the failure to capture the
-			following definitions within the included terminology: <a>accessibility API</a>
-			<a>ontology</a>
-			<a>class</a>
-			<a>event</a>.</p>
 	</body>
 </html>


### PR DESCRIPTION
* Use terms from source specs
* use current w3c respec profile
* fix terms when referenced to be infomatively referenced when necessary
* removed linkfix hack


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/37.html" title="Last updated on Apr 23, 2021, 10:43 PM UTC (2df13a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/37/75470c0...2df13a5.html" title="Last updated on Apr 23, 2021, 10:43 PM UTC (2df13a5)">Diff</a>