### PR TITLE
Fixes for endnote and biblioentry deprecation

### DIFF
--- a/index.html
+++ b/index.html
@@ -818,6 +818,16 @@
 					<div class="role-description">
 						<p>A list of external references cited in the work, which may be to print or digital
 							sources.</p>
+						<p>The element carrying the <code>doc-bibliography</code>
+							<a class="termref">role</a> MUST contain at least one descendant list containing the
+							bibliography entries (if the entries are subdivided, for example alphabetically, the element
+							would contain more than one list).</p>
+						<p>User Agents MUST expose the list items in these lists using the platform accessibility API
+							mappings for an individual entry.</p>
+						<p>Lists nested within an entry have no special significance. User Agents MUST NOT expose these
+							list items using the platform accessibility API mappings for an individual entry.</p>
+						<p>Authors MUST NOT apply the <code>doc-bibliography</code> role directly to the list containing
+							the entries.</p>
 						<pre class="example highlight">&lt;section role="doc-bibliography"&gt;
    &lt;h2&gt;Select Bibliography&lt;/h2&gt;
    &lt;ul&gt;
@@ -1613,8 +1623,7 @@
 							in the WAI-ARIA specification, it is not valid as a child of the <rref>list</rref> role. As
 							the <rref>doc-endnotes</rref> role already identifies a section of endnotes, authors are
 							instead advised to use the <rref>list</rref> and <rref>listitem</rref> roles when native
-							HTML elements cannot be used to structure the entries. The <rref>doc-footnote</rref> role
-							can be used within each list item to identify individual notes when necessary.</p>
+							HTML elements cannot be used to structure the entries.</p>
 					</div>
 					<table class="role-features">
 						<caption>Characteristics of <code>doc-endnote</code>:</caption>
@@ -1698,19 +1707,43 @@
 					<rdef>doc-endnotes</rdef>
 					<div class="role-description">
 						<p>A collection of notes at the end of a work or a section within it.</p>
-						<p>Note that the <code>doc-endnotes</code>
-							<a class="termref">role</a> is never applied directly to the list of endnotes.</p>
+						<p>The element carrying the <code>doc-endnotes</code>
+							<a class="termref">role</a> MUST contain at least one descendant list containing the
+							endnotes (if the notes are subdivided, for example by chapter, the element would contain
+							more than one list).</p>
+						<p>User Agents MUST expose the list items in these lists using the platform accessibility API
+							mappings for an individual endnote.</p>
+						<p>Lists nested within an endnote have no special significance. User Agents MUST NOT expose
+							these list items using the platform accessibility API mappings for an individual
+							endnote.</p>
+						<p>Authors MUST NOT declare elements with the role <rref>doc-footnote</rref> within the endnotes
+							as it is redundant with the implied role.</p>
+						<p>Authors MUST NOT apply the <code>doc-endnotes</code> role directly to the list containing the
+							endnotes.</p>
 						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
    &lt;h2&gt;Notes&lt;/h2&gt;
    &lt;ol&gt;
       &lt;li id="6baa07af"&gt;
-         &lt;p role="doc-footnote"&gt;Additional results of this study can be found at &#8230; &lt;/p&gt;
+         &lt;p&gt;Additional results of this study can be found at &#8230; &lt;/p&gt;
       &lt;/li&gt;
       &lt;li id="7b2c0555"&gt;
-         &lt;p role="doc-footnote"&gt;&#8230;&lt;/p&gt;
+         &lt;p&gt;&#8230;&lt;/p&gt;
       &lt;/li&gt;
       &#8230;
    &lt;/ol&gt;
+&lt;/section&gt;</pre>
+						<pre class="example highlight">&lt;section role="doc-endnotes"&gt;
+   &lt;h2&gt;Notes&lt;/h2&gt;
+   &lt;section>
+      &lt;h3>Canto I&lt;/h3>
+      &lt;div role="list&gt;
+         &lt;div role="listitem"&gt;
+            &lt;p&gt;1. The use of alliteration here &#8230; &lt;/p&gt;
+         &lt;/div&gt;
+         &#8230;
+      &lt;/div>
+   &lt;/section&gt;
+   &#8230;
 &lt;/section&gt;</pre>
 					</div>
 					<table class="role-features">


### PR DESCRIPTION
As discussed in issue #38 and separately, this pull request:

- clarifies the requirement for at least one list descendant for doc-bibliography and doc-endnotes;
- clarifies the processing of list items by user agents (i.e., excluding nested lists)
- requires that doc-footnote not be used in endnotes;
- removes the doc-footnote role from endnotes example;
- added a second example of endnotes with multiple lists.

I've taken the more restrictive approach of requiring that doc-footnote not be used within the endnotes for now, but before merging this pull request I'll check with the publishing groups.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/39.html" title="Last updated on Aug 5, 2021, 4:09 PM UTC (e3cb0fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/39/8de4657...e3cb0fb.html" title="Last updated on Aug 5, 2021, 4:09 PM UTC (e3cb0fb)">Diff</a>