### PR TITLE
Remove restriction on page breaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,8 +151,8 @@
 			<section id="target-audience">
 				<h3>Target Audience</h3>
 				<p>This specification defines a module of <abbr title="Accessible Rich Internet Applications"
-						>WAI-ARIA</abbr> for digital publishing, including [=roles=], [=states=], [=ARIA/properties=] and values. It impacts several
-					audiences:</p>
+						>WAI-ARIA</abbr> for digital publishing, including [=roles=], [=states=], [=ARIA/properties=]
+					and values. It impacts several audiences:</p>
 				<ul>
 					<li>[=User agents=] that process content containing <abbr
 							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Digital Publishing <abbr
@@ -229,9 +229,8 @@
 					<h4>Authoring Tools</h4>
 					<p>Many of the requirements in the definitions of the <abbr
 							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Digital Publishing <abbr
-							title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
-						[=roles=], [=states=] and 
-							[=ARIA/properties=] can be checked automatically during the development process, similar to
+							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> [=roles=], [=states=] and
+						[=ARIA/properties=] can be checked automatically during the development process, similar to
 						other quality control processes used for validating code. To assist authors who are creating
 						digital publications, such as EPUB, can compare the semantic structure of Digital Publishing
 							<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles from the <abbr
@@ -266,8 +265,7 @@
 		<section class="normative" id="roles">
 			<h2>Digital Publishing Roles</h2>
 			<p>This section defines additions to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
-				<a class="termref">roles</a> model
-				 and describes the characteristics and properties of all <a
+				<a class="termref">roles</a> model and describes the characteristics and properties of all <a
 					data-lt="role" class="termref">roles</a>. See <a href="#roles" class="specref">ARIA Roles</a> for
 				descriptions of the fields provided by this module.</p>
 			<section id="role_definitions">
@@ -2931,6 +2929,14 @@
 						<p>Authors MUST ensure the name of the page break is an end user-consumable page number that
 							identifies the page that is beginning so that assistive technologies can announce the page
 							as needed (e.g., in a command to identify the current page).</p>
+						<p>The page break locator MUST precede the content of the page it identifies. If a page includes
+							a <a href="#doc-pageheader">header</a>, the page break locator SHOULD be located before it,
+							even if the header includes a visible page number. The page break locator may be used with
+							the page number in a page header if the number precedes all other content in the header.</p>
+						<p>When reproducing page break locators from a static page equivalent, it is sometimes the case
+							that words are hyphenated across pages. When this happens, the page break locator SHOULD be
+							placed either before or after the word to ensure it does not interfere with text-to-speech
+							playback.</p>
 						<aside class="example">
 							<p>The following example shows three equivalent patterns for marking up page breaks in
 								digital publications. Either the <code>aria-label</code> or <code>title</code>
@@ -3219,7 +3225,6 @@
 							a repeating template that contains (possibly truncated) items such as the document title,
 							current section, author name(s), and page number.</p>
 						<p>The <code>doc-pageheader</code> role MUST be used on every instance of the page header.</p>
-						<p>The <code>doc-pageheader</code> MUST NOT contain the <rref>doc-pagebreak</rref>.</p>
 						<p>Assistive technologies MAY allow the user to read the document content continuously without
 							interruption from the page header.</p>
 						<pre class="example highlight">&lt;section role="doc-pageheader"&gt;


### PR DESCRIPTION
This pull request removes the restriction that page break locators are never allowed in the header and adds clarifications about use to the doc-pagebreak definition.

Specifically, I've added these two paragraphs:

> The page break locator MUST precede the content of the page it identifies. If a page includes a [header](https://github.com/w3c/dpub-aria/compare/fix/issue-45?expand=1#doc-pageheader), the page break locator SHOULD be located before it, even if the header includes a visible page number. The page break locator may be used with the page number in a page header if the number precedes all other content in the header.

> 
> When reproducing page break locators from a static page equivalent, it is sometimes the case that words are hyphenated across pages. When this happens, the page break locator SHOULD be placed either before or after the word to ensure it does not interfere with text-to-speech playback.

Before I take this out of draft status, do these requirements need any tweaking and is there anything else about page break placement I've missed @TzviyaSiegman @avneeshsingh @GeorgeKerscher @clapierre ?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/46.html" title="Last updated on Jan 24, 2023, 7:49 PM UTC (7b5b8b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/46/25288b6...7b5b8b3.html" title="Last updated on Jan 24, 2023, 7:49 PM UTC (7b5b8b3)">Diff</a>