### PR TITLE
Add dfn tags to glossary example

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,8 +151,8 @@
 			<section id="target-audience">
 				<h3>Target Audience</h3>
 				<p>This specification defines a module of <abbr title="Accessible Rich Internet Applications"
-						>WAI-ARIA</abbr> for digital publishing, including [=roles=], [=states=], [=ARIA/properties=] and values. It impacts several
-					audiences:</p>
+						>WAI-ARIA</abbr> for digital publishing, including [=roles=], [=states=], [=ARIA/properties=]
+					and values. It impacts several audiences:</p>
 				<ul>
 					<li>[=User agents=] that process content containing <abbr
 							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Digital Publishing <abbr
@@ -229,9 +229,8 @@
 					<h4>Authoring Tools</h4>
 					<p>Many of the requirements in the definitions of the <abbr
 							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> and Digital Publishing <abbr
-							title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
-						[=roles=], [=states=] and 
-							[=ARIA/properties=] can be checked automatically during the development process, similar to
+							title="Accessible Rich Internet Applications">WAI-ARIA</abbr> [=roles=], [=states=] and
+						[=ARIA/properties=] can be checked automatically during the development process, similar to
 						other quality control processes used for validating code. To assist authors who are creating
 						digital publications, such as EPUB, can compare the semantic structure of Digital Publishing
 							<abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> roles from the <abbr
@@ -266,8 +265,7 @@
 		<section class="normative" id="roles">
 			<h2>Digital Publishing Roles</h2>
 			<p>This section defines additions to the <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>
-				<a class="termref">roles</a> model
-				 and describes the characteristics and properties of all <a
+				<a class="termref">roles</a> model and describes the characteristics and properties of all <a
 					data-lt="role" class="termref">roles</a>. See <a href="#roles" class="specref">ARIA Roles</a> for
 				descriptions of the fields provided by this module.</p>
 			<section id="role_definitions">
@@ -2268,8 +2266,10 @@
 						</tbody>
 					</table>
 				</div>
+				
 				<div class="role">
 					<rdef>doc-foreword</rdef>
+					
 					<div class="role-description">
 						<p>An introductory section that precedes the work, typically not written by the author of the
 							work.</p>
@@ -2360,13 +2360,14 @@
 					<rdef>doc-glossary</rdef>
 					<div class="role-description">
 						<p>A brief dictionary of new, uncommon, or specialized terms used in the content.</p>
+
 						<p>The structure of a glossary SHOULD make it possible for end users to identify each term and
-							associated definition (e.g., using the [[HTML]] <code>dl</code> or <code>dfn</code>
-							elements).</p>
+							associated definition (e.g., using the [[HTML]] <code>dfn</code> element).</p>
+
 						<pre class="example highlight">&lt;section role="doc-glossary" aria-label="glossary"&gt;
    &lt;dl&gt;
       &#8230;
-      &lt;dt id="bcc0f155"&gt;Credit default swap&lt;/dt&gt;
+      &lt;dt id="bcc0f155"&gt;&lt;dfn&gt;Credit default swap&lt;/dfn&gt;&lt;/dt&gt;
       &lt;dd&gt;
          A credit default swap effectively insures against
          default by a borrower.


### PR DESCRIPTION
Fixes #47


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/48.html" title="Last updated on Jan 24, 2023, 8:59 PM UTC (a0deb69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/48/25288b6...a0deb69.html" title="Last updated on Jan 24, 2023, 8:59 PM UTC (a0deb69)">Diff</a>