### PR TITLE
editorial: github contributors section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4496,7 +4496,7 @@
 
       <p>The following people contributed to the development of this document.</p>
       <ul id="gh-contributors">
-          <!-- list of contributors will appear here, along with link to their GitHub profiles -->
+        <!-- list of contributors will appear here, along with link to their GitHub profiles -->
       </ul>
       <section class="section" id="ack_dpub">
         <h3>Participants active in the DPUB-ARIA task force at the time of publication</h3>

--- a/index.html
+++ b/index.html
@@ -4495,7 +4495,9 @@
       <h2>Acknowledgments</h2>
 
       <p>The following people contributed to the development of this document.</p>
-
+      <ul id="gh-contributors">
+          <!-- list of contributors will appear here, along with link to their GitHub profiles -->
+      </ul>
       <section class="section" id="ack_dpub">
         <h3>Participants active in the DPUB-ARIA task force at the time of publication</h3>
 


### PR DESCRIPTION
Adds a new GH contributors section, matching other ARIA specs.

See w3c/aria-common#103 for more background.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/60.html" title="Last updated on Nov 10, 2023, 1:22 PM UTC (7dd7c4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/60/fcca819...7dd7c4b.html" title="Last updated on Nov 10, 2023, 1:22 PM UTC (7dd7c4b)">Diff</a>