### PR TITLE
Removed the requirements to imply the deprecated doc-biblioentry and doc-endnote roles on list item descendants

### DIFF
--- a/index.html
+++ b/index.html
@@ -4444,9 +4444,9 @@
         <ul>
           <!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
           <li>
-            01-Dec-2023: Removed the requirements to imply list items descendants of <code>doc-bibliography</code> and 
-            <code>doc-endnotes</code> are <code>doc-biblioentry</code> and <code>doc-endnote</code> 
-          </li> 
+            01-Dec-2023: Removed the requirements to imply list items descendants of <code>doc-bibliography</code> and <code>doc-endnotes</code> are <code>doc-biblioentry</code> and
+            <code>doc-endnote</code>
+          </li>
         </ul>
       </section>
 
@@ -4454,11 +4454,11 @@
         <h3>Substantive changes since the <a href="https://www.w3.org/TR/dpub-aria-1.0/">DPUB-ARIA 1.0 Recommendation</a></h3>
 
         <ul>
-        	<li>
-              20-Sep-2021: Clarified ambiguities in the formatting and processing of endnote and bibliography lists and require that the <rref>doc-footnote</rref> role not be used within endnotes. See
-              <a href="https://github.com/w3c/dpub-aria/issues/38">issue 38</a>.
-        	</li>
-        	<li>
+          <li>
+            20-Sep-2021: Clarified ambiguities in the formatting and processing of endnote and bibliography lists and require that the <rref>doc-footnote</rref> role not be used within endnotes. See
+            <a href="https://github.com/w3c/dpub-aria/issues/38">issue 38</a>.
+          </li>
+          <li>
             24-Feb-2021: Changed required accessible name for <rref>doc-part</rref> to false to match the other landmark roles. See <a href="https://github.com/w3c/dpub-aria/issues/34">issue 34</a>.
           </li>
           <li>02-Oct-2020: Added new <rref>doc-pageheader</rref> and <rref>doc-pagefooter</rref> roles. See <a href="https://github.com/w3c/dpub-aria/issues/28">issue 28</a>.</li>

--- a/index.html
+++ b/index.html
@@ -894,10 +894,6 @@
               subdivided, for example alphabetically, the element would contain more than one list).
             </p>
 
-            <p>User Agents MUST expose the list items in these lists using the platform accessibility API mappings for an individual entry.</p>
-
-            <p>Lists nested within an entry have no special significance. User Agents MUST NOT expose these list items using the platform accessibility API mappings for an individual entry.</p>
-
             <p>Authors MUST NOT apply the <code>doc-bibliography</code> role directly to the list containing the entries.</p>
 
             <pre class="example highlight">
@@ -1850,10 +1846,6 @@
               The element carrying the <code>doc-endnotes</code> <a class="termref">role</a> MUST contain at least one descendant list containing the endnotes (if the notes are subdivided, for example
               by chapter, the element would contain more than one list).
             </p>
-
-            <p>User Agents MUST expose the list items in these lists using the platform accessibility API mappings for an individual endnote.</p>
-
-            <p>Lists nested within an endnote have no special significance. User Agents MUST NOT expose these list items using the platform accessibility API mappings for an individual endnote.</p>
 
             <p>Authors MUST NOT declare elements with the role <rref>doc-footnote</rref> within the endnotes as it is redundant with the implied role.</p>
 
@@ -4447,14 +4439,14 @@
       <h2>Change Log</h2>
 
       <section id="changelog-recent">
-        <h3>Substantive changes since the <a href="https://www.w3.org/TR/2021/WD-dpub-aria-1.1-20210826/">First Public Working Draft</a></h3>
+        <h3>Substantive changes since the <a href="https://www.w3.org/TR/2023/WD-dpub-aria-1.1-20231030/">last Working Draft</a></h3>
 
         <ul>
           <!-- EdNote: After each WD publish, move contents of this list into the next one below. -->
           <li>
-            20-Sep-2021: Clarified ambiguities in the formatting and processing of endnote and bibliography lists and require that the <rref>doc-footnote</rref> role not be used within endnotes. See
-            <a href="https://github.com/w3c/dpub-aria/issues/38">issue 38</a>.
-          </li>
+            01-Dec-2023: Removed the requirements to imply list items descendants of <code>doc-bibliography</code> and 
+            <code>doc-endnotes</code> are <code>doc-biblioentry</code> and <code>doc-endnote</code> 
+          </li> 
         </ul>
       </section>
 
@@ -4462,7 +4454,11 @@
         <h3>Substantive changes since the <a href="https://www.w3.org/TR/dpub-aria-1.0/">DPUB-ARIA 1.0 Recommendation</a></h3>
 
         <ul>
-          <li>
+        	<li>
+              20-Sep-2021: Clarified ambiguities in the formatting and processing of endnote and bibliography lists and require that the <rref>doc-footnote</rref> role not be used within endnotes. See
+              <a href="https://github.com/w3c/dpub-aria/issues/38">issue 38</a>.
+        	</li>
+        	<li>
             24-Feb-2021: Changed required accessible name for <rref>doc-part</rref> to false to match the other landmark roles. See <a href="https://github.com/w3c/dpub-aria/issues/34">issue 34</a>.
           </li>
           <li>02-Oct-2020: Added new <rref>doc-pageheader</rref> and <rref>doc-pagefooter</rref> roles. See <a href="https://github.com/w3c/dpub-aria/issues/28">issue 28</a>.</li>


### PR DESCRIPTION
This pull request is a continuation of the changes made in https://github.com/w3c/dpub-aam/pull/38

It removes the normative requirements that led to those implied mappings.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/61.html" title="Last updated on Dec 1, 2023, 7:07 PM UTC (335143a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/61/fcca819...335143a.html" title="Last updated on Dec 1, 2023, 7:07 PM UTC (335143a)">Diff</a>