### PR TITLE
Updated list of contributors

### DIFF
--- a/index.html
+++ b/index.html
@@ -4509,7 +4509,7 @@
         <li>Avneesh Singh (DAISY Consortium)</li>
         <li>Valerie Young (Igalia)</li>
       </ul>
-      
+
       <div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -4490,19 +4490,26 @@
     <section class="appendix informative section" id="acknowledgements">
       <h2>Acknowledgments</h2>
 
-      <p>The following people contributed to the development of this document.</p>
+      <p>The following people contributed to the development of this document:</p>
 
-      <section class="section" id="ack_dpub">
-        <h3>Participants active in the DPUB-ARIA task force at the time of publication</h3>
-
-        <ul>
-          <li>Michael Cooper (W3C Staff)</li>
-          <li>Joanmarie Diggs (Igalia, S.L.)</li>
-          <li>Matt Garrish (DAISY Consortium)</li>
-          <li>James Nurthen (Adobe)</li>
-          <li>Tzviya Siegman (Wiley)</li>
-        </ul>
-      </section>
+      <ul>
+        <li>James Craig (Apple Inc.)</li>
+        <li>Romain Deltour (DAISY Consortium)</li>
+        <li>Joanmarie Diggs (Igalia)</li>
+        <li>Matt Garrish (DAISY Consortium)</li>
+        <li>George Kerscher (DAISY Consortium)</li>
+        <li>Peter Krautzberger (W3C Invited Experts)</li>
+        <li>Charles Lapierre (Benetech)</li>
+        <li>Aaron Leventhal (Google)</li>
+        <li>Daniel Montalvo (W3C Staff)</li>
+        <li>James Nurthen (Adobe)</li>
+        <li>Scott O'Hara (Microsoft Corporation)</li>
+        <li>Gregorio Pellegrino (Fondazione LIA)</li>
+        <li>Tzviya Siegman (Wiley)</li>
+        <li>Avneesh Singh (DAISY Consortium)</li>
+        <li>Valerie Young (Igalia)</li>
+      </ul>
+      
       <div data-include="common/acknowledgements/funders.html" data-include-replace="true"></div>
     </section>
   </body>


### PR DESCRIPTION
Removes the section about participants in a task force and updates the list as best I can with people who have contributed to issue and pull requests incorporated in this revision, as well as adding participants from the publishing side.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/pull/66.html" title="Last updated on Jan 8, 2024, 4:55 PM UTC (091dc67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-aria/66/7e6f382...091dc67.html" title="Last updated on Jan 8, 2024, 4:55 PM UTC (091dc67)">Diff</a>